### PR TITLE
Remove CI Roadmap items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The imaging ingestion component is currently comprised of six (6) subcomponents:
 **Installation and Deployment on Kubernetes procedure:**
   1. Install the [Alvearie Imaging Ingestion Operator](imaging-ingestion-operator) 
   2. Create a PostgreSQL database for the imaging manifest data
-  3. Declare a [DICOM Event Driven Ingestion](docs/event-driven-ingestion/overview.md), binding it to the provided PostgreSQL database
+  3. Declare a [DICOM Event Driven Ingestion](docs/event-driven-ingestion/overview.md), binding it to the provided  database
   4. Create a S3 Object bucket for each storage space needed
   5. Declare a [DICOMweb Ingestion Service](docs/dicomweb-ingestion-service/overview.md) for each storage space
   6. Declare [DICOM Instance Binding](docs/dicom-instance-binding/overview.md) and [DICOM Study Binding](docs/dicom-study-binding/overview.md) as needed for distribution of DICOM instances and DICOM study notifications.

--- a/docs/event-driven-ingestion/overview.md
+++ b/docs/event-driven-ingestion/overview.md
@@ -27,6 +27,8 @@ metadata:
 data:
   DATASOURCE_MAX_SIZE: '50'
   DB_HOST: img-ingest-db
+  # Default DB_KIND is 'postgresql'.  To use DB2, declare 'db2' as the DB_KIND.
+  #DB_KIND: db2
   DB_NAME: img-manifest
   DB_PORT: '5432'
   EVENT_LOOPS_POOL_SIZE: '20'
@@ -62,6 +64,8 @@ metadata:
   # All other subcomponents will need to reference this.
   name: core
 spec:
+  # Default container uses PostgreSQL.  To use DB2 override the default image
+  #image: alvearie/dicom-event-driven-ingestion-db2:0.0.1
   # Reference to the database configuration
   databaseConfigName: db-config
   # Reference to the dataabase credential
@@ -73,9 +77,11 @@ spec:
     minReplicas: 0
 ```
 
-## Using an alternative to the PostgreSQL database
+## Using alternative SQL databases
   The Event Driven Ingestion Service uses a relational database to maintain the imaging data manifest.  Implemented in Quarkus, it is possible to support a number of different database providers by modifying a few properties in [application.properties](../../dicom-event-driven-ingestion/src/main/resources/application.properties).  Refer to the [Quarkus Datasources](https://quarkus.io/guides/datasource) documentation for details.  
   
 As part of building a native image, the JDBC driver is included in a single binary within the container image.  With the current build, in order to use use an alternative database provider, a separate container needs to be built for each provider.  The provided *Kubernetes* operator allows alternative containers to be configured with the *DicomEventDrivenIngestion* custom resource.  
+
+The current build action creates two different containers; one for PostgreSQL, and one for IBM DB2.  
   
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,9 +3,6 @@
 
 ## Planned
 
--  Integrate into a Continuous Integration (CI) toolchain service and create a build process
-
-
 -  Improve the scope of support in the DIMSE Proxy for bidirectional use-cases.  Current capability is limited to unidirectional ingestion.
 
 

--- a/imaging-ingestion-operator/README.md
+++ b/imaging-ingestion-operator/README.md
@@ -6,7 +6,27 @@ Each of the subcomponents of imaging ingestion are represented as individual *Ku
 
 ## Deployment
 
+Apply the provided YAML to the cluster.  Without modification, this YAML will:
+-  Creates a **imaging-ingestion** namespace, 
+-  Adds the provided *Custom Resource Definitions* to the cluster
+-  Creates the *ServiceAccount*, *Role*, and *RoleBinding* for the operator in the imaging-ingestion namespace
+-  Creates a *ControllerManagerConfig* to manage the scheduling of the operator and a *ConfigMap* for operator leader election state
+-  Deploys the operator to the imaging-ingestion namespace
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Alvearie/imaging-ingestion/main/imaging-ingestion-operator/deploy/manifests.yaml
 ```
+
+## Custom Resource Definitions
+
+  Each of the provided CRDs has an example and in-line documentation with the subcomponent documentation pages.
+  
+- [DicomEventDrivenIngestion](docs/event-driven-ingestion/overview.md)
+- [DicomwebIngestionService](docs/dicomweb-ingestion-service/overview.md) 
+- [DicomInstanceBinding](docs/dicom-instance-binding/overview.md) 
+- [DicomStudyBinding](docs/dicom-study-binding/overview.md)
+- [DimseIngestionService](docs/dimse-ingestion-service/overview.md)
+- [DimseProxy](docs/dimse-proxy/overview.md) 
+
+
+


### PR DESCRIPTION
Add additional details on how to use the operator as well as using DB2 now that we have container images being built.