### PR TITLE
Better knative detection

### DIFF
--- a/imaging-ingestion-operator/common/constants.go
+++ b/imaging-ingestion-operator/common/constants.go
@@ -15,8 +15,7 @@ const (
 	KnativeServingKind     = "Service"
 	KnativeEventingKind    = "Broker"
 
-	AutoDetectTick    = 30 * time.Second
-	StartupDetectTick = 5 * time.Second
+	AutoDetectTick    = 2 * time.Minute
 	RequeueDelay      = 5 * time.Minute
 	RequeueDelayError = 5 * time.Second
 


### PR DESCRIPTION
* If knative is not detected on startup, start manager with only
controllers that can work without knative.
* Check knative state change in auto detect and restart manager pod
to enable/disable supported APIs

Signed-off-by: Jeesmon Jacob <jjacob@us.ibm.com>