### PR TITLE
Update common.go

### DIFF
--- a/imaging-ingestion-operator/model/common.go
+++ b/imaging-ingestion-operator/model/common.go
@@ -27,8 +27,7 @@ func MergeEnvs(a []v1.EnvVar, b []v1.EnvVar) []v1.EnvVar {
 		found := false
 		for i, aa := range a {
 			if aa.Name == bb.Name {
-				aa.Value = bb.Value
-				a[i] = aa
+				a[i] = *bb.DeepCopy()
 				found = true
 				break
 			}


### PR DESCRIPTION
Allow merging of `EnvVar`s that have different value sources (`Value` vs `ValueFrom`)