### PR TITLE
add test and fix mergeenvs

### DIFF
--- a/imaging-ingestion-operator/go.mod
+++ b/imaging-ingestion-operator/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.21.4
 	k8s.io/apimachinery v0.21.4
 	k8s.io/client-go v0.21.4

--- a/imaging-ingestion-operator/model/common.go
+++ b/imaging-ingestion-operator/model/common.go
@@ -27,8 +27,7 @@ func MergeEnvs(a []v1.EnvVar, b []v1.EnvVar) []v1.EnvVar {
 		found := false
 		for i, aa := range a {
 			if aa.Name == bb.Name {
-				aa.Value = bb.Value
-				a[i] = aa
+				a[i] = *bb.DeepCopy()
 				found = true
 				break
 			}

--- a/imaging-ingestion-operator/model/common_test.go
+++ b/imaging-ingestion-operator/model/common_test.go
@@ -4,17 +4,16 @@
 SPDX-License-Identifier: Apache-2.0
 */
 
-package model_test
+package model
 
 import (
 	"testing"
 
-	"github.com/Alvearie/imaging-ingestion/imaging-ingestion-operator/model"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
-// TestMergeEnvsEmptyEmpty calls model.MergeEnvs with a empty slices, checking
+// TestMergeEnvsEmptyEmpty calls MergeEnvs with a empty slices, checking
 // for a returned empty slice
 func TestMergeEnvsEmptyEmpty(t *testing.T) {
 	assert := require.New(t)
@@ -22,12 +21,12 @@ func TestMergeEnvsEmptyEmpty(t *testing.T) {
 	a := []corev1.EnvVar{}
 	b := []corev1.EnvVar{}
 
-	merged := model.MergeEnvs(a, b)
+	merged := MergeEnvs(a, b)
 
 	assert.Empty(merged)
 }
 
-// TestMergeEnvsEmptyNonEmpty calls model.MergeEnvs with an empty slice for A, and non-empty slice for B,
+// TestMergeEnvsEmptyNonEmpty calls MergeEnvs with an empty slice for A, and non-empty slice for B,
 // checking for a returned slice with the same values of B
 func TestMergeEnvsEmptyNonEmpty(t *testing.T) {
 	assert := require.New(t)
@@ -35,20 +34,20 @@ func TestMergeEnvsEmptyNonEmpty(t *testing.T) {
 	a := []corev1.EnvVar{}
 	b := []corev1.EnvVar{{Name: "key1", Value: "v1"}} // 1 entry only
 
-	merged := model.MergeEnvs(a, b)
+	merged := MergeEnvs(a, b)
 
 	assert.Equal(b, merged)
 
 	// We append another value to b and merge again
 	b = append(b, corev1.EnvVar{Name: "key2", Value: "v2"})
 
-	merged = model.MergeEnvs(a, b)
+	merged = MergeEnvs(a, b)
 
 	assert.Equal(b, merged)
 	assert.Len(merged, 2)
 }
 
-// TestMergeEnvsNonEmptyEmpty calls model.MergeEnvs with a non-empty slice for A, and empty slice for B,
+// TestMergeEnvsNonEmptyEmpty calls MergeEnvs with a non-empty slice for A, and empty slice for B,
 // checking for a returned slice with the same values of A
 func TestMergeEnvsNonEmptyEmpty(t *testing.T) {
 	assert := require.New(t)
@@ -56,20 +55,20 @@ func TestMergeEnvsNonEmptyEmpty(t *testing.T) {
 	a := []corev1.EnvVar{{Name: "key1", Value: "v1"}} // 1 entry only
 	b := []corev1.EnvVar{}
 
-	merged := model.MergeEnvs(a, b)
+	merged := MergeEnvs(a, b)
 
 	assert.Equal(a, merged)
 
 	// We append another value to a and merge again
 	a = append(a, corev1.EnvVar{Name: "key2", Value: "v2"})
 
-	merged = model.MergeEnvs(a, b)
+	merged = MergeEnvs(a, b)
 
 	assert.Equal(a, merged)
 	assert.Len(merged, 2)
 }
 
-// TestMergeEnvsNoOverlap calls model.MergeEnvs with a non-empty slice for A, and non-empty slice for B,
+// TestMergeEnvsNoOverlap calls MergeEnvs with a non-empty slice for A, and non-empty slice for B,
 // There are not duplicate keys between A and B entries
 // Checking for a returned slice with the values of both A and B
 func TestMergeEnvsNoOverlap(t *testing.T) {
@@ -78,7 +77,7 @@ func TestMergeEnvsNoOverlap(t *testing.T) {
 	a := []corev1.EnvVar{{Name: "A_KEY_1", Value: "value A 1"}} // 1 entry only
 	b := []corev1.EnvVar{{Name: "B_KEY_1", Value: "value B 1"}} // 1 entry only
 
-	merged := model.MergeEnvs(a, b)
+	merged := MergeEnvs(a, b)
 
 	assert.Len(merged, 2)
 	assert.Contains(merged, a[0], b[0])
@@ -86,7 +85,7 @@ func TestMergeEnvsNoOverlap(t *testing.T) {
 	// We append another value to A and merge again
 	a = append(a, corev1.EnvVar{Name: "A_KEY_2", Value: "value A 2"})
 
-	merged = model.MergeEnvs(a, b)
+	merged = MergeEnvs(a, b)
 
 	assert.Len(merged, 3)
 	assert.Contains(merged, a[0], a[1], b[0])
@@ -94,13 +93,13 @@ func TestMergeEnvsNoOverlap(t *testing.T) {
 	// We append another value to B and merge again
 	b = append(b, corev1.EnvVar{Name: "B_KEY_2", Value: "value B 2"})
 
-	merged = model.MergeEnvs(a, b)
+	merged = MergeEnvs(a, b)
 
 	assert.Len(merged, 4)
 	assert.Contains(merged, a[0], a[1], b[0], b[1])
 }
 
-// TestMergeEnvsOverlap calls model.MergeEnvs with a non-empty slice for A, and non-empty slice for B,
+// TestMergeEnvsOverlap calls MergeEnvs with a non-empty slice for A, and non-empty slice for B,
 // There are duplicate keys between A and B entries
 // Checking for a returned slice with the values of both A and B, where B values take precedence when same key
 func TestMergeEnvsOverlap(t *testing.T) {
@@ -113,7 +112,7 @@ func TestMergeEnvsOverlap(t *testing.T) {
 	a := []corev1.EnvVar{{Name: commonKey, Value: aValue}} // 1 entry only
 	b := []corev1.EnvVar{{Name: commonKey, Value: bValue}} // 1 entry only
 
-	merged := model.MergeEnvs(a, b)
+	merged := MergeEnvs(a, b)
 
 	assert.Len(merged, 1)
 	assert.Contains(merged, b[0]) // should contain only the value from B
@@ -122,7 +121,7 @@ func TestMergeEnvsOverlap(t *testing.T) {
 	newA := corev1.EnvVar{Name: "A_KEY_2", Value: "value A 2"}
 	a = append(a, newA)
 
-	merged = model.MergeEnvs(a, b)
+	merged = MergeEnvs(a, b)
 
 	assert.Len(merged, 2)
 	assert.Contains(merged, newA, b[0])
@@ -130,13 +129,13 @@ func TestMergeEnvsOverlap(t *testing.T) {
 	// We append another value to B and merge again
 	b = append(b, corev1.EnvVar{Name: "B_KEY_2", Value: "value B 2"})
 
-	merged = model.MergeEnvs(a, b)
+	merged = MergeEnvs(a, b)
 
 	assert.Len(merged, 3)
 	assert.Contains(merged, newA, b[0], b[1])
 }
 
-// TestMergeEnvsWithValueFrom calls model.MergeEnvs with a non-empty slice for A, and non-empty slice for B,
+// TestMergeEnvsWithValueFrom calls MergeEnvs with a non-empty slice for A, and non-empty slice for B,
 // There are duplicate keys between A and B entries
 // Checking for a returned slice with the values of both A and B, where B values take precedence when same key
 // The EnvVar used can also contain entries with ValueFrom instead of Value
@@ -153,7 +152,7 @@ func TestMergeEnvsWithValueFromInBSlice(t *testing.T) {
 	a := []corev1.EnvVar{aEnvVar1} // 1 entry only
 	b := []corev1.EnvVar{bEnvVar1} // 1 entry only, with a ValueFrom env var
 
-	merged := model.MergeEnvs(a, b)
+	merged := MergeEnvs(a, b)
 
 	assert.Len(merged, 1)
 	assert.Contains(merged, bEnvVar1) // should contain only the value from B
@@ -162,7 +161,7 @@ func TestMergeEnvsWithValueFromInBSlice(t *testing.T) {
 	aEnvVar2 := corev1.EnvVar{Name: "A_KEY_2", Value: "value A 2"}
 	a = append(a, aEnvVar2)
 
-	merged = model.MergeEnvs(a, b)
+	merged = MergeEnvs(a, b)
 
 	assert.Len(merged, 2)
 	assert.Contains(merged, aEnvVar2, bEnvVar1)
@@ -172,7 +171,7 @@ func TestMergeEnvsWithValueFromInBSlice(t *testing.T) {
 	bEnvVar2 := corev1.EnvVar{Name: "B_KEY_2", Value: "value B 2"}
 	b = append(b, bEnvVar2)
 
-	merged = model.MergeEnvs(a, b)
+	merged = MergeEnvs(a, b)
 
 	// We should have the three values:
 	assert.Len(merged, 3)
@@ -186,7 +185,7 @@ func TestMergeEnvsWithValueFromInBSlice(t *testing.T) {
 	}
 	a = append(a, aEnvVar3)
 
-	merged = model.MergeEnvs(a, b)
+	merged = MergeEnvs(a, b)
 
 	assert.Len(merged, 3)
 	assert.Contains(merged, bEnvVar1, aEnvVar2, bEnvVar2)

--- a/imaging-ingestion-operator/model/common_test.go
+++ b/imaging-ingestion-operator/model/common_test.go
@@ -1,0 +1,203 @@
+/*
+(C) Copyright IBM Corp. 2021
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/Alvearie/imaging-ingestion/imaging-ingestion-operator/model"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestMergeEnvsEmptyEmpty calls model.MergeEnvs with a empty slices, checking
+// for a returned empty slice
+func TestMergeEnvsEmptyEmpty(t *testing.T) {
+	assert := require.New(t)
+
+	a := []corev1.EnvVar{}
+	b := []corev1.EnvVar{}
+
+	merged := model.MergeEnvs(a, b)
+
+	assert.Empty(merged)
+}
+
+// TestMergeEnvsEmptyNonEmpty calls model.MergeEnvs with an empty slice for A, and non-empty slice for B,
+// checking for a returned slice with the same values of B
+func TestMergeEnvsEmptyNonEmpty(t *testing.T) {
+	assert := require.New(t)
+
+	a := []corev1.EnvVar{}
+	b := []corev1.EnvVar{{Name: "key1", Value: "v1"}} // 1 entry only
+
+	merged := model.MergeEnvs(a, b)
+
+	assert.Equal(b, merged)
+
+	// We append another value to b and merge again
+	b = append(b, corev1.EnvVar{Name: "key2", Value: "v2"})
+
+	merged = model.MergeEnvs(a, b)
+
+	assert.Equal(b, merged)
+	assert.Len(merged, 2)
+}
+
+// TestMergeEnvsNonEmptyEmpty calls model.MergeEnvs with a non-empty slice for A, and empty slice for B,
+// checking for a returned slice with the same values of A
+func TestMergeEnvsNonEmptyEmpty(t *testing.T) {
+	assert := require.New(t)
+
+	a := []corev1.EnvVar{{Name: "key1", Value: "v1"}} // 1 entry only
+	b := []corev1.EnvVar{}
+
+	merged := model.MergeEnvs(a, b)
+
+	assert.Equal(a, merged)
+
+	// We append another value to a and merge again
+	a = append(a, corev1.EnvVar{Name: "key2", Value: "v2"})
+
+	merged = model.MergeEnvs(a, b)
+
+	assert.Equal(a, merged)
+	assert.Len(merged, 2)
+}
+
+// TestMergeEnvsNoOverlap calls model.MergeEnvs with a non-empty slice for A, and non-empty slice for B,
+// There are not duplicate keys between A and B entries
+// Checking for a returned slice with the values of both A and B
+func TestMergeEnvsNoOverlap(t *testing.T) {
+	assert := require.New(t)
+
+	a := []corev1.EnvVar{{Name: "A_KEY_1", Value: "value A 1"}} // 1 entry only
+	b := []corev1.EnvVar{{Name: "B_KEY_1", Value: "value B 1"}} // 1 entry only
+
+	merged := model.MergeEnvs(a, b)
+
+	assert.Len(merged, 2)
+	assert.Contains(merged, a[0], b[0])
+
+	// We append another value to A and merge again
+	a = append(a, corev1.EnvVar{Name: "A_KEY_2", Value: "value A 2"})
+
+	merged = model.MergeEnvs(a, b)
+
+	assert.Len(merged, 3)
+	assert.Contains(merged, a[0], a[1], b[0])
+
+	// We append another value to B and merge again
+	b = append(b, corev1.EnvVar{Name: "B_KEY_2", Value: "value B 2"})
+
+	merged = model.MergeEnvs(a, b)
+
+	assert.Len(merged, 4)
+	assert.Contains(merged, a[0], a[1], b[0], b[1])
+}
+
+// TestMergeEnvsOverlap calls model.MergeEnvs with a non-empty slice for A, and non-empty slice for B,
+// There are duplicate keys between A and B entries
+// Checking for a returned slice with the values of both A and B, where B values take precedence when same key
+func TestMergeEnvsOverlap(t *testing.T) {
+	assert := require.New(t)
+
+	commonKey := "SAME_KEY_1"
+	aValue := "value A"
+	bValue := "value B"
+
+	a := []corev1.EnvVar{{Name: commonKey, Value: aValue}} // 1 entry only
+	b := []corev1.EnvVar{{Name: commonKey, Value: bValue}} // 1 entry only
+
+	merged := model.MergeEnvs(a, b)
+
+	assert.Len(merged, 1)
+	assert.Contains(merged, b[0]) // should contain only the value from B
+
+	// We append another value to A and merge again
+	newA := corev1.EnvVar{Name: "A_KEY_2", Value: "value A 2"}
+	a = append(a, newA)
+
+	merged = model.MergeEnvs(a, b)
+
+	assert.Len(merged, 2)
+	assert.Contains(merged, newA, b[0])
+
+	// We append another value to B and merge again
+	b = append(b, corev1.EnvVar{Name: "B_KEY_2", Value: "value B 2"})
+
+	merged = model.MergeEnvs(a, b)
+
+	assert.Len(merged, 3)
+	assert.Contains(merged, newA, b[0], b[1])
+}
+
+// TestMergeEnvsWithValueFrom calls model.MergeEnvs with a non-empty slice for A, and non-empty slice for B,
+// There are duplicate keys between A and B entries
+// Checking for a returned slice with the values of both A and B, where B values take precedence when same key
+// The EnvVar used can also contain entries with ValueFrom instead of Value
+func TestMergeEnvsWithValueFromInBSlice(t *testing.T) {
+	assert := require.New(t)
+
+	commonKey := "SAME_KEY_1"
+	aEnvVar1 := corev1.EnvVar{Name: commonKey, Value: "Value A1"}
+	bEnvVar1 := corev1.EnvVar{
+		Name:      commonKey,
+		ValueFrom: getTestEnvVarSource("localObjectRef1", "keySelectorName1"),
+	}
+
+	a := []corev1.EnvVar{aEnvVar1} // 1 entry only
+	b := []corev1.EnvVar{bEnvVar1} // 1 entry only, with a ValueFrom env var
+
+	merged := model.MergeEnvs(a, b)
+
+	assert.Len(merged, 1)
+	assert.Contains(merged, bEnvVar1) // should contain only the value from B
+
+	// We append another value to A and merge again
+	aEnvVar2 := corev1.EnvVar{Name: "A_KEY_2", Value: "value A 2"}
+	a = append(a, aEnvVar2)
+
+	merged = model.MergeEnvs(a, b)
+
+	assert.Len(merged, 2)
+	assert.Contains(merged, aEnvVar2, bEnvVar1)
+
+	// We append another value to B and merge again
+
+	bEnvVar2 := corev1.EnvVar{Name: "B_KEY_2", Value: "value B 2"}
+	b = append(b, bEnvVar2)
+
+	merged = model.MergeEnvs(a, b)
+
+	// We should have the three values:
+	assert.Len(merged, 3)
+	assert.Contains(merged, bEnvVar1, aEnvVar2, bEnvVar2)
+
+	// We append another "ValueFrom" value to A, with the same key used for bEnvVar2 ("B_KEY_2")
+	// This new value should not exist after merging
+	aEnvVar3 := corev1.EnvVar{
+		Name:      "B_KEY_2",
+		ValueFrom: getTestEnvVarSource("localObjectRef2", "keySelectorName2"),
+	}
+	a = append(a, aEnvVar3)
+
+	merged = model.MergeEnvs(a, b)
+
+	assert.Len(merged, 3)
+	assert.Contains(merged, bEnvVar1, aEnvVar2, bEnvVar2)
+}
+
+// getTestEnvVarSource creates a test EnvVarSource to apply to
+func getTestEnvVarSource(lorName string, key string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: lorName},
+			Key:                  key,
+		},
+	}
+}


### PR DESCRIPTION
The `common.MergeEnvs` method works only for `EnvVar`s that are set with `Name` and `Value`. It will not work for env vars created with `ValueFrom` field.

This method is eventually used in `stow_service.go` and `wado_service.go`. Where it merges Env Vars from the current state with the CR (and hardcoded) env vars. But if the Current state is modified with Env Vars with `ValueFrom`, the merging will fail because it will try to assign a `Value` to an Env Var that already has a `ValueFrom`.

I could not find a better test at the controller level to test the scenario of modifying a `knative.dev/serving/pkg/apis/serving/v1/Service` resource with the `ValueFrom` env vars, and testing how the Operator will reconcile that. But I added unit testing for the method in this PR.