### PR TITLE
StudyRevisionEvent.changeSets.deletions test can cause a null pointer…

### DIFF
--- a/dicom-event-driven-ingestion/src/main/java/org/alvearie/imaging/ingestion/StudyRevisonEventBuilder.java
+++ b/dicom-event-driven-ingestion/src/main/java/org/alvearie/imaging/ingestion/StudyRevisonEventBuilder.java
@@ -91,7 +91,7 @@ public class StudyRevisonEventBuilder {
                                     String changeReference = String.format("%s/%s", s.getSeriesInstanceUID(), inst.getSopInstanceUID());
                                     if (ie.initialRevision.equals(studyEntity.revision)) {
                                         additions.add(changeReference);
-                                    } else if (studyEntity.revision > 0 && ie.deletedRevision.equals(studyEntity.revision)) {
+                                    } else if (studyEntity.revision > 0 && ie.deletedRevision != null && ie.deletedRevision.equals(studyEntity.revision)) {
                                         deletions.add(changeReference);
                                     } else if (ie.lastModified.isAfter(studyEntity.revisionTime)) {
                                         modifications.add(changeReference);


### PR DESCRIPTION
… when the DB column for deletion tracking is unset

Signed-off-by: Richard Duggan <rduggan@ca.ibm.com>