### PR TITLE
Updates to inject service level configurations to DICOM Web STOW and WADO Services

### DIFF
--- a/imaging-ingestion-operator/api/v1alpha1/dicomwebingestionservice_types.go
+++ b/imaging-ingestion-operator/api/v1alpha1/dicomwebingestionservice_types.go
@@ -19,6 +19,9 @@ type DicomwebIngestionServiceSpec struct {
 	// DICOM Event Driven Ingestion Name
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	DicomEventDrivenIngestionName string `json:"dicomEventDrivenIngestionName"`
+	// Service Config Name
+	//+operator-sdk:csv:customresourcedefinitions:type=spec
+	ServiceConfigName string `json:"serviceConfigName,omitempty"`
 	// Bucket Config Name
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	BucketConfigName string `json:"bucketConfigName,omitempty"`

--- a/imaging-ingestion-operator/bundle/manifests/imaging-ingestion-operator.clusterserviceversion.yaml
+++ b/imaging-ingestion-operator/bundle/manifests/imaging-ingestion-operator.clusterserviceversion.yaml
@@ -87,7 +87,7 @@ metadata:
             "dicomEventDrivenIngestionName": "core",
             "imagePullPolicy": "Always",
             "providerName": "provider",
-            "serviceConfigName": "dicomweb-service-config",
+            "serviceConfigName": "dicomweb-svc-config",
             "stowService": {
               "concurrency": 0,
               "maxReplicas": 3,

--- a/imaging-ingestion-operator/bundle/manifests/imaging-ingestion-operator.clusterserviceversion.yaml
+++ b/imaging-ingestion-operator/bundle/manifests/imaging-ingestion-operator.clusterserviceversion.yaml
@@ -87,6 +87,7 @@ metadata:
             "dicomEventDrivenIngestionName": "core",
             "imagePullPolicy": "Always",
             "providerName": "provider",
+            "serviceConfigName": "dicomweb-service-config",
             "stowService": {
               "concurrency": 0,
               "maxReplicas": 3,
@@ -452,6 +453,9 @@ spec:
       - description: Provider Name
         displayName: Provider Name
         path: providerName
+      - description: Service Config Name
+        displayName: Service Config Name
+        path: serviceConfigName
       - description: STOW Service Spec
         displayName: Stow Service
         path: stowService

--- a/imaging-ingestion-operator/bundle/manifests/imaging-ingestion.alvearie.org_dicomwebingestionservices.yaml
+++ b/imaging-ingestion-operator/bundle/manifests/imaging-ingestion.alvearie.org_dicomwebingestionservices.yaml
@@ -71,6 +71,9 @@ spec:
               providerName:
                 description: Provider Name
                 type: string
+              serviceConfigName:
+                description: Service Config Name
+                type: string
               stowService:
                 description: STOW Service Spec
                 properties:

--- a/imaging-ingestion-operator/config/crd/bases/imaging-ingestion.alvearie.org_dicomwebingestionservices.yaml
+++ b/imaging-ingestion-operator/config/crd/bases/imaging-ingestion.alvearie.org_dicomwebingestionservices.yaml
@@ -73,6 +73,9 @@ spec:
               providerName:
                 description: Provider Name
                 type: string
+              serviceConfigName:
+                description: Service Config Name
+                type: string
               stowService:
                 description: STOW Service Spec
                 properties:

--- a/imaging-ingestion-operator/config/samples/imaging-ingestion_v1alpha1_dicomwebingestionservice.yaml
+++ b/imaging-ingestion-operator/config/samples/imaging-ingestion_v1alpha1_dicomwebingestionservice.yaml
@@ -8,7 +8,7 @@ spec:
   bucketSecretName: imaging-ingestion
   dicomEventDrivenIngestionName: core
   providerName: provider
-  serviceConfigName: dicomweb-service-config
+  serviceConfigName: dicomweb-svc-config
   stowService:
     concurrency: 0
     maxReplicas: 3

--- a/imaging-ingestion-operator/config/samples/imaging-ingestion_v1alpha1_dicomwebingestionservice.yaml
+++ b/imaging-ingestion-operator/config/samples/imaging-ingestion_v1alpha1_dicomwebingestionservice.yaml
@@ -8,6 +8,7 @@ spec:
   bucketSecretName: imaging-ingestion
   dicomEventDrivenIngestionName: core
   providerName: provider
+  serviceConfigName: dicomweb-service-config
   stowService:
     concurrency: 0
     maxReplicas: 3

--- a/imaging-ingestion-operator/controllers/dicomwebingestionservice_reconciler.go
+++ b/imaging-ingestion-operator/controllers/dicomwebingestionservice_reconciler.go
@@ -20,6 +20,7 @@ func (r *DicomwebIngestionServiceReconciler) GetDesiredState(currentState *Dicom
 	desired := common.DesiredResourceState{}
 	desired = desired.AddAction(r.GetBucketSecretDesiredState(currentState, cr))
 	desired = desired.AddAction(r.GetBucketConfigDesiredState(currentState, cr))
+	desired = desired.AddAction(r.GetServiceConfigDesiredState(currentState, cr))
 	desired = desired.AddAction(r.GetStowServiceDesiredState(currentState, cr))
 	desired = desired.AddAction(r.GetWadoServiceDesiredState(currentState, cr))
 	desired = desired.AddAction(r.GetStowSinkBindingDesiredState(currentState, cr))
@@ -43,6 +44,17 @@ func (i *DicomwebIngestionServiceReconciler) GetBucketConfigDesiredState(state *
 		return common.GenericErrorAction{
 			Ref: errors.New("Missing Bucket Config"),
 			Msg: "Missing Bucket Config",
+		}
+	}
+
+	return nil
+}
+
+func (i *DicomwebIngestionServiceReconciler) GetServiceConfigDesiredState(state *DicomwebIngestionServiceState, cr *v1alpha1.DicomwebIngestionService) common.ControllerAction {
+	if state.BucketConfig == nil {
+		return common.GenericErrorAction{
+			Ref: errors.New("Missing DICOMWeb Service Config"),
+			Msg: "Missing DICOMWeb Service Config",
 		}
 	}
 

--- a/imaging-ingestion-operator/deploy/manifests.yaml
+++ b/imaging-ingestion-operator/deploy/manifests.yaml
@@ -545,6 +545,9 @@ spec:
               providerName:
                 description: Provider Name
                 type: string
+              serviceConfigName:
+                description: Service Config Name
+                type: string
               stowService:
                 description: STOW Service Spec
                 properties:

--- a/imaging-ingestion-operator/model/service_config.go
+++ b/imaging-ingestion-operator/model/service_config.go
@@ -1,0 +1,30 @@
+/*
+(C) Copyright IBM Corp. 2021
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package model
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ServiceConfig is the Service Config
+func ServiceConfig() *corev1.ConfigMap {
+	return &corev1.ConfigMap{}
+}
+
+// ServiceConfigSelector is the  Service Config Selector
+func ServiceConfigSelector(name, namespace string) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+}
+
+func ServiceConfigReconciled(currentState *corev1.ConfigMap) *corev1.ConfigMap {
+	reconciled := currentState.DeepCopy()
+	return reconciled
+}


### PR DESCRIPTION
The change includes injecting environment variables to STOW and WADO services using config maps.
This will allow overriding specific configurations.