### PR TITLE
added quarkus.http.limits.max-body-size to handle large dcm files

### DIFF
--- a/dicomweb-stow-service/src/main/resources/application.properties
+++ b/dicomweb-stow-service/src/main/resources/application.properties
@@ -18,3 +18,5 @@ wado.internal.endpoint=${WADO_INTERNAL_ENDPOINT:http://127.0.0.1.nip.io}
 wado.external.endpoint=${WADO_EXTERNAL_ENDPOINT:http://127.0.0.1.nip.io}
 
 event.source=stow.imaging-ingestion.svc.cluster.local
+quarkus.http.limits.max-body-size=40M
+

--- a/dicomweb-wado-service/src/main/resources/application.properties
+++ b/dicomweb-wado-service/src/main/resources/application.properties
@@ -24,3 +24,4 @@ event.source=wado.imaging-ingestion.svc.cluster.local
 
 wado.internal.endpoint=${WADO_INTERNAL_ENDPOINT:http://127.0.0.1.nip.io}
 wado.external.endpoint=${WADO_EXTERNAL_ENDPOINT:http://127.0.0.1.nip.io}
+quarkus.http.limits.max-body-size=40M


### PR DESCRIPTION
Signed-off-by: pbhallam <pushpa.b.sinha@gmail.com>